### PR TITLE
Improved NetworkTables capture 

### DIFF
--- a/lib/src/main/java/dev/doglog/DogLogOptions.java
+++ b/lib/src/main/java/dev/doglog/DogLogOptions.java
@@ -16,7 +16,7 @@ public record DogLogOptions(
      */
     boolean ntPublish,
     /** Whether all NetworkTables fields should be saved to the log file. */
-    boolean captureNt,
+    NTCaptureMode captureNt,
     /**
      * Whether driver station data (robot enable state and joystick inputs) should be saved to the
      * log file. Because of a limitation in WPILib, this option can't be disabled once it has been
@@ -30,6 +30,12 @@ public record DogLogOptions(
     /** The maximum size of the log entry queue to use. */
     int logEntryQueueCapacity) {
   public static final double LOOP_PERIOD_SECONDS = 0.02;
+  
+  public sealed interface NTCaptureMode {
+    record Explicit(boolean enabled) implements NTCaptureMode {}
+    record Default() implements NTCaptureMode {}
+    record Constrained(String... paths) implements NTCaptureMode {}
+  }
 
   /**
    * Create a new options object using the default options. The default options are safe for a
@@ -40,7 +46,7 @@ public record DogLogOptions(
    */
   public DogLogOptions() {
     // Default options
-    this(false, false, false, true, true, 1000);
+    this(false, new NTCaptureMode.Default(), false, true, true, 1000);
   }
 
   /**
@@ -79,7 +85,17 @@ public record DogLogOptions(
   public DogLogOptions withCaptureNt(boolean captureNt) {
     return new DogLogOptions(
         ntPublish(),
-        captureNt,
+        new NTCaptureMode.Explicit(captureNt),
+        captureDs(),
+        logExtras(),
+        captureConsole(),
+        logEntryQueueCapacity());
+  }
+  
+  public DogLogOptions withCaptureNTFrom(String... paths) {
+    return new DogLogOptions(
+        ntPublish(),
+        new NTCaptureMode.Constrained(paths),
         captureDs(),
         logExtras(),
         captureConsole(),

--- a/lib/src/main/java/dev/doglog/internal/log_thread/reporters/CombinedReporter.java
+++ b/lib/src/main/java/dev/doglog/internal/log_thread/reporters/CombinedReporter.java
@@ -33,7 +33,7 @@ public class CombinedReporter {
   
   private void updateDataLogState(DogLogOptions options) {
     if (options.captureNt() instanceof NTCaptureMode.Explicit casted) {
-      allNtIsCaptured = casted.enabled();
+      allNtIsCaptured = casted.enabled() && options.ntPublish();
     } else {
       allNtIsCaptured = false;
     }

--- a/lib/src/main/java/dev/doglog/internal/log_thread/reporters/CombinedReporter.java
+++ b/lib/src/main/java/dev/doglog/internal/log_thread/reporters/CombinedReporter.java
@@ -11,6 +11,9 @@ import dev.doglog.internal.log_thread.StructRegistry;
 import edu.wpi.first.hal.HALUtil;
 import edu.wpi.first.util.struct.Struct;
 import edu.wpi.first.util.struct.StructSerializable;
+import edu.wpi.first.wpilibj.DataLogManager;
+
+import static dev.doglog.DogLogOptions.*;
 
 public class CombinedReporter {
   /** The NetworkTables table to log to, if NetworkTables publishing is enabled. */
@@ -19,11 +22,30 @@ public class CombinedReporter {
   private final DataLogReporter dataLogReporter;
   // Default to null
   private NetworkTablesReporter ntReporter;
+  private boolean allNtIsCaptured;
 
   public CombinedReporter(DogLogOptions initialOptions) {
     dataLogReporter = new DataLogReporter(LOG_TABLE, initialOptions);
 
     setOptions(initialOptions);
+    updateDataLogState(initialOptions);
+  }
+  
+  private void updateDataLogState(DogLogOptions options) {
+    if (options.captureNt() instanceof NTCaptureMode.Explicit casted) {
+      allNtIsCaptured = casted.enabled();
+    } else if (options.captureNt() instanceof NTCaptureMode.Constrained) {
+      allNtIsCaptured = false;
+    } else {
+      try {
+        // sorry... more spooky reflection(there's literally no other way to do this)
+        var ntCaptureActiveField = DataLogManager.class.getDeclaredField("m_ntLoggerEnabled");
+        ntCaptureActiveField.setAccessible(true);
+        allNtIsCaptured = (Boolean) ntCaptureActiveField.get(null);
+      } catch (Exception e) {
+        allNtIsCaptured = false;
+      }
+    }
   }
 
   public void log(long timestamp, String key, boolean[] value) {
@@ -31,7 +53,9 @@ public class CombinedReporter {
       return;
     }
 
-    dataLogReporter.log(timestamp, key, value);
+    if (!allNtIsCaptured) {
+      dataLogReporter.log(timestamp, key, value);
+    }
 
     if (ntReporter != null) {
       ntReporter.log(timestamp, key, value);
@@ -39,7 +63,9 @@ public class CombinedReporter {
   }
 
   public void log(long timestamp, String key, boolean value) {
-    dataLogReporter.log(timestamp, key, value);
+    if (!allNtIsCaptured) {
+      dataLogReporter.log(timestamp, key, value);
+    }
 
     if (ntReporter != null) {
       ntReporter.log(timestamp, key, value);
@@ -51,7 +77,9 @@ public class CombinedReporter {
       return;
     }
 
-    dataLogReporter.log(timestamp, key, value);
+    if (!allNtIsCaptured) {
+      dataLogReporter.log(timestamp, key, value);
+    }
 
     if (ntReporter != null) {
       ntReporter.log(timestamp, key, value);
@@ -59,7 +87,9 @@ public class CombinedReporter {
   }
 
   public void log(long timestamp, String key, double value) {
-    dataLogReporter.log(timestamp, key, value);
+    if (!allNtIsCaptured) {
+      dataLogReporter.log(timestamp, key, value);
+    }
 
     if (ntReporter != null) {
       ntReporter.log(timestamp, key, value);
@@ -71,7 +101,9 @@ public class CombinedReporter {
       return;
     }
 
-    dataLogReporter.log(timestamp, key, value);
+    if (!allNtIsCaptured) {
+      dataLogReporter.log(timestamp, key, value);
+    }
 
     if (ntReporter != null) {
       ntReporter.log(timestamp, key, value);
@@ -79,7 +111,9 @@ public class CombinedReporter {
   }
 
   public void log(long timestamp, String key, float value) {
-    dataLogReporter.log(timestamp, key, value);
+    if (!allNtIsCaptured) {
+      dataLogReporter.log(timestamp, key, value);
+    }
 
     if (ntReporter != null) {
       ntReporter.log(timestamp, key, value);
@@ -91,7 +125,9 @@ public class CombinedReporter {
       return;
     }
 
-    dataLogReporter.log(timestamp, key, value);
+    if (!allNtIsCaptured) {
+      dataLogReporter.log(timestamp, key, value);
+    }
 
     if (ntReporter != null) {
       ntReporter.log(timestamp, key, value);
@@ -99,7 +135,9 @@ public class CombinedReporter {
   }
 
   public void log(long timestamp, String key, long value) {
-    dataLogReporter.log(timestamp, key, value);
+    if (!allNtIsCaptured) {
+      dataLogReporter.log(timestamp, key, value);
+    }
 
     if (ntReporter != null) {
       ntReporter.log(timestamp, key, value);
@@ -115,7 +153,9 @@ public class CombinedReporter {
       return;
     }
 
-    dataLogReporter.log(timestamp, key, value);
+    if (!allNtIsCaptured) {
+      dataLogReporter.log(timestamp, key, value);
+    }
 
     if (ntReporter != null) {
       ntReporter.log(timestamp, key, value);
@@ -127,7 +167,9 @@ public class CombinedReporter {
       return;
     }
 
-    dataLogReporter.log(timestamp, key, value);
+    if (!allNtIsCaptured) {
+      dataLogReporter.log(timestamp, key, value);
+    }
 
     if (ntReporter != null) {
       ntReporter.log(timestamp, key, value);
@@ -143,8 +185,10 @@ public class CombinedReporter {
     if (value == null) {
       return;
     }
-
-    dataLogReporter.log(timestamp, key, value, customTypeString);
+    
+    if (!allNtIsCaptured) {
+      dataLogReporter.log(timestamp, key, value, customTypeString);
+    }
 
     if (ntReporter != null) {
       ntReporter.log(timestamp, key, value, customTypeString);
@@ -156,7 +200,9 @@ public class CombinedReporter {
       return;
     }
 
-    dataLogReporter.log(timestamp, key, struct, value);
+    if (!allNtIsCaptured) {
+      dataLogReporter.log(timestamp, key, struct, value);
+    }
     if (ntReporter != null) {
       ntReporter.log(timestamp, key, struct, value);
     }
@@ -177,7 +223,9 @@ public class CombinedReporter {
   }
 
   private <T> void log(long timestamp, String key, Struct<T> struct, T value) {
-    dataLogReporter.log(timestamp, key, struct, value);
+    if (!allNtIsCaptured) {
+      dataLogReporter.log(timestamp, key, struct, value);
+    }
     if (ntReporter != null) {
       ntReporter.log(timestamp, key, struct, value);
     }
@@ -198,6 +246,7 @@ public class CombinedReporter {
   }
 
   public void setOptions(DogLogOptions options) {
+    updateDataLogState(options);
     // Avoid recreating the logger if the options haven't changed
     if (options.ntPublish() && ntReporter == null) {
       ntReporter = new NetworkTablesReporter(LOG_TABLE);

--- a/lib/src/main/java/dev/doglog/internal/log_thread/reporters/CombinedReporter.java
+++ b/lib/src/main/java/dev/doglog/internal/log_thread/reporters/CombinedReporter.java
@@ -34,17 +34,8 @@ public class CombinedReporter {
   private void updateDataLogState(DogLogOptions options) {
     if (options.captureNt() instanceof NTCaptureMode.Explicit casted) {
       allNtIsCaptured = casted.enabled();
-    } else if (options.captureNt() instanceof NTCaptureMode.Constrained) {
-      allNtIsCaptured = false;
     } else {
-      try {
-        // sorry... more spooky reflection(there's literally no other way to do this)
-        var ntCaptureActiveField = DataLogManager.class.getDeclaredField("m_ntLoggerEnabled");
-        ntCaptureActiveField.setAccessible(true);
-        allNtIsCaptured = (Boolean) ntCaptureActiveField.get(null);
-      } catch (Exception e) {
-        allNtIsCaptured = false;
-      }
+      allNtIsCaptured = false;
     }
   }
 

--- a/lib/src/main/java/dev/doglog/internal/log_thread/reporters/DataLogReporter.java
+++ b/lib/src/main/java/dev/doglog/internal/log_thread/reporters/DataLogReporter.java
@@ -166,12 +166,10 @@ public class DataLogReporter implements Reporter {
   public void setOptions(DogLogOptions options) {
     DataLogManager.logConsoleOutput(options.captureConsole());
 
-    DataLogManager.logNetworkTables(
-        options.captureNt() instanceof NTCaptureMode.Explicit casted &&
-            casted.enabled()
-    );
-    
-    if (options.captureNt() instanceof NTCaptureMode.Constrained casted) {
+    if (options.captureNt() instanceof NTCaptureMode.Explicit casted) {
+      DataLogManager.logNetworkTables(casted.enabled());
+    } else if (options.captureNt() instanceof NTCaptureMode.Constrained casted) {
+      DataLogManager.logNetworkTables(false);
       for (String path: casted.paths()) {
         NetworkTableInstance.getDefault().startEntryDataLog(
             DataLogManager.getLog(),

--- a/lib/src/main/java/dev/doglog/internal/log_thread/reporters/DataLogReporter.java
+++ b/lib/src/main/java/dev/doglog/internal/log_thread/reporters/DataLogReporter.java
@@ -5,6 +5,7 @@
 package dev.doglog.internal.log_thread.reporters;
 
 import dev.doglog.DogLogOptions;
+import edu.wpi.first.networktables.NetworkTableInstance;
 import edu.wpi.first.util.datalog.BooleanArrayLogEntry;
 import edu.wpi.first.util.datalog.BooleanLogEntry;
 import edu.wpi.first.util.datalog.DataLog;
@@ -27,6 +28,8 @@ import edu.wpi.first.wpilibj.RobotBase;
 import edu.wpi.first.wpilibj.RuntimeType;
 import java.util.HashMap;
 import java.util.Map;
+
+import static dev.doglog.DogLogOptions.*;
 
 /** Logs to a WPILib {@link DataLog}. */
 public class DataLogReporter implements Reporter {
@@ -163,7 +166,19 @@ public class DataLogReporter implements Reporter {
   public void setOptions(DogLogOptions options) {
     DataLogManager.logConsoleOutput(options.captureConsole());
 
-    DataLogManager.logNetworkTables(options.captureNt());
+    DataLogManager.logNetworkTables(
+        options.captureNt() instanceof NTCaptureMode.Explicit casted &&
+            casted.enabled()
+    );
+    
+    if (options.captureNt() instanceof NTCaptureMode.Constrained casted) {
+      for (String path: casted.paths()) {
+        NetworkTableInstance.getDefault().startEntryDataLog(
+            DataLogManager.getLog(),
+            path, path
+        );
+      }
+    }
 
     if (options.captureDs()) {
       DriverStation.startDataLog(log);


### PR DESCRIPTION
Currently, doglog nt capture has a couple of problems:
a. If it is enabled, it will end up capturing its own NT logs, causing fields to duplicate.
b. Every DogLog.setOptions() call with a new DogLogOptions will disable nt capture without people knowing it. This is bad if DogLog's .withNtCapture is not used(and many new coders can fall into this trap, especially w/ epilogue examples explicitly recommending it)
c. It forces you to capture all of NT instead of only a small portion.

This PR should hopefully solve all of these problems.

1. if DogLogOptions.withNtCapture(true) is called, DogLog will no longer log to datalog(instead, nt capture will do the datalogging instead).
2. If DogLogOptions.withNtCapture is not called at all, DogLog will respect whatever current DataLogManager.logNetworkTables(boolean) config there is. In many places(i.e epilogue), it is recommended to call DataLogManager.start() to start capturing NT, but configuring DogLogOptions will automatically turn that off without the user knowing(now, it should not anymore).
3. DogLogOptions.withCaptureNtFrom(String... paths) method is added to DogLogOptions which allows NT capture from only specific paths(I.E from alerts, limelight data, etc.)