### PR TITLE
Ensure Java 17 compatibility for users

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,2 +1,2 @@
 jdk:
-  - openjdk21
+  - openjdk17

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -72,10 +72,10 @@ java {
 	withSourcesJar()
 	withJavadocJar()
 
-	sourceCompatibility = JavaVersion.VERSION_21
-	targetCompatibility = JavaVersion.VERSION_21
+	sourceCompatibility = JavaVersion.VERSION_17
+	targetCompatibility = JavaVersion.VERSION_17
 }
-var javaVersion = "21"
+var javaVersion = "17"
 
 
 javadoc {

--- a/mise.toml
+++ b/mise.toml
@@ -1,3 +1,3 @@
 [tools]
-java = "temurin-21"
+java = "temurin-17"
 node = "22"

--- a/test-project/build.gradle
+++ b/test-project/build.gradle
@@ -5,8 +5,8 @@ plugins {
 }
 
 java {
-	sourceCompatibility = JavaVersion.VERSION_21
-	targetCompatibility = JavaVersion.VERSION_21
+	sourceCompatibility = JavaVersion.VERSION_17
+	targetCompatibility = JavaVersion.VERSION_17
 }
 
 def ROBOT_MAIN_CLASS = "frc.robot.Main"


### PR DESCRIPTION
Downgrade Java compatibility to 17 to ensure end-users running Java 17 can still use the library.

This PR updates `lib/build.gradle`, `test-project/build.gradle`, `jitpack.yml`, and `mise.toml` to target Java 17, allowing the library to be used by a wider range of Java environments while maintaining forward compatibility.

---
<a href="https://cursor.com/background-agent?bcId=bc-a76e3172-9d10-4375-9aaa-5b6b87c5d15e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a76e3172-9d10-4375-9aaa-5b6b87c5d15e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

